### PR TITLE
#49 Geolocation doesn't have to be allowed by user

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,5 +11,6 @@
   },
   "chrome_url_overrides" : {
     "newtab": "index.html"
-  }
+  },
+  "permissions": ["geolocation"]
 }


### PR DESCRIPTION
Geolocation doesn't have to be allowed by user. It's enabled during installation.