### PR TITLE
Fix time and quick links on first start

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app-my-spotlight",
   "description": "Your own simple start page, strongly inspired by Windows Spotlight. 💡 PROJECT IDEA: A public project developed by the community.",
   "homepage": "https://github.com/PlayXman/app-my-spotlight#readme",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "engines": {
     "node": ">=12",
     "npm": ">=6.14"

--- a/src/components/QuickLinksWidget.vue
+++ b/src/components/QuickLinksWidget.vue
@@ -28,19 +28,19 @@ export default {
   data() {
     return {
       mail: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       calendar: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       disk: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       notes: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       loading: true

--- a/src/components/settings/categories/SettingsCategoryQuickLinks.vue
+++ b/src/components/settings/categories/SettingsCategoryQuickLinks.vue
@@ -85,19 +85,19 @@ export default {
   data() {
     return {
       mail: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       calendar: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       disk: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       notes: {
-        enabled: true,
+        enabled: false,
         url: ""
       },
       loading: true

--- a/src/components/settings/categories/SettingsCategoryTime.vue
+++ b/src/components/settings/categories/SettingsCategoryTime.vue
@@ -25,8 +25,8 @@ export default {
   components: { SettingsInputSwitch, SettingsSection },
   data() {
     return {
-      isOn: true,
-      hour24: true,
+      isOn: false,
+      hour24: false,
       loading: true
     };
   },

--- a/src/components/settings/categories/SettingsCategoryTodolist.vue
+++ b/src/components/settings/categories/SettingsCategoryTodolist.vue
@@ -6,6 +6,7 @@
       label="Your personal api token"
       :value="apiKey"
       :disabled="loading"
+      placeholder="17ba6935968..."
     />
     <SettingsSectionHint>
       Go to the


### PR DESCRIPTION
The time and quick links were enabled even if they were supposed to be turned off.