### PR TITLE
Fix Todoist requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app-my-spotlight",
   "description": "Your own simple start page, strongly inspired by Windows Spotlight. 💡 PROJECT IDEA: A public project developed by the community.",
   "homepage": "https://github.com/PlayXman/app-my-spotlight#readme",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "engines": {
     "node": ">=12",
     "npm": ">=6.14"

--- a/src/models/todo/Todoist.js
+++ b/src/models/todo/Todoist.js
@@ -4,7 +4,7 @@ import TodolistSettings from "../../models/settings/TodolistSettings";
 import TodoProject from "../../models/todo/TodoProject";
 
 /** @type {string} */
-const API_URL = "https://api.todoist.com/sync/v8/sync";
+const API_URL = "https://api.todoist.com/sync/v9/sync";
 /** @type {number} In minutes */
 const UPDATE_INTERVAL = 2;
 /** @type {string} */


### PR DESCRIPTION
Update the API version to `v9`. `v8` has been deprecated and removed on 30/11/2022.

https://developer.todoist.com/sync/v9/#getting-started