### PR TITLE
Fix Todoist sync

### DIFF
--- a/src/models/todo/Todoist.js
+++ b/src/models/todo/Todoist.js
@@ -91,12 +91,12 @@ class Todoist {
    */
   async _fetchAllData() {
     const params = new URLSearchParams({
-      token: await this._userToken(),
       sync_token: "*",
       resource_types: '["items", "projects"]'
     });
     const headers = new Headers();
     headers.append("Content-Type", "application/x-www-form-urlencoded");
+    headers.append("Authorization", `Bearer ${await this._userToken()}`);
 
     const items = [];
     const projects = [];


### PR DESCRIPTION
 Auth token cannot be part of URL search params anymore.

### The correct request
```
POST https://api.todoist.com/sync/v9/sync
Content-Type: application/x-www-form-urlencoded
Authorization: Bearer XXXXXXXXXX

sync_token="*"&resource_types=["items", "projects"]
```

### Before
```
POST https://api.todoist.com/sync/v9/sync
Content-Type: application/x-www-form-urlencoded

token=XXXXXXX&sync_token="*"&resource_types=["items", "projects"]
```